### PR TITLE
Typo on Docker page 'GaphQL'

### DIFF
--- a/content/install/docker.md
+++ b/content/install/docker.md
@@ -8,7 +8,7 @@ weight: 1
 
 The first step to start using Space Cloud is setting it up. Space Cloud requires several components to be running for proper functions. The most important components are:
 
-- **Gateway:** Responsible for ingress traffic and generation of REST / GaphQL APIs
+- **Gateway:** Responsible for ingress traffic and generation of REST / GraphQL APIs
 - **Runner:** Responsible for intra-cluster traffic and policy enforcement
 - **Container Registry:** Responsible for storing docker images. We won't be needing this for local setup.
 


### PR DESCRIPTION
Fixed typo on Docker page 'GaphQL'